### PR TITLE
Fixed steam osk from opening on game launch

### DIFF
--- a/src/launch.rs
+++ b/src/launch.rs
@@ -96,6 +96,7 @@ pub fn launch_cmd(
     cmd.push_str("SDL_JOYSTICK_HIDAPI=0 ");
     cmd.push_str("ENABLE_GAMESCOPE_WSI=0 ");
     cmd.push_str("PROTON_DISABLE_HIDRAW=1 ");
+    cmd.push_str("SteamDeck=0 ");
 
     if cfg.force_sdl && !win {
         let mut path_sdl = "/ubuntu12_32/steam-runtime/usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0";


### PR DESCRIPTION
I was having an issue where if party deck was launched through steam then the steam onscreen keyboard world popup for every game instance launched. SteamDeck=0 env seems to fix this.

<img width="1920" height="1080" alt="Screenshot_20250912_180637" src="https://github.com/user-attachments/assets/734cbbdf-48c1-4561-8bfb-9c1181e1fb0e" />


