### PR TITLE
Case unsensitive check for .exe and .bat (useful for old games like NFS Underground 2)

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -135,7 +135,10 @@ impl Handler {
     }
 
     pub fn win(&self) -> bool {
-        self.exec.ends_with(".exe") || self.exec.ends_with(".bat")
+        self.exec.ends_with(".exe") || 
+        self.exec.ends_with(".EXE") || 
+        self.exec.ends_with(".bat") ||
+        self.exec.ends_with(".BAT")
     }
 
     pub fn is_saved_handler(&self) -> bool {


### PR DESCRIPTION
I'm writing an handler for NFS Underground 2 and I had to rename the executable to speed2.exe instead of SPEED2.EXE to let it recognize as a Proton game.