### PR TITLE
feat: add mangohud toggle

### DIFF
--- a/src/app/app_pages.rs
+++ b/src/app/app_pages.rs
@@ -198,6 +198,7 @@ impl PartyApp {
                 );
 
             ui.checkbox(&mut h.use_goldberg, "Emulate Steam Client");
+            ui.checkbox(&mut h.use_mangohud, "Enable MangoHud");
         });
 
         h.steam_appid = match &self.installed_steamapps[selected_index] {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -44,6 +44,8 @@ pub struct Handler {
 
     pub pause_between_starts: Option<f64>,
 
+    #[serde(default)]
+    pub use_mangohud: bool,
     pub use_goldberg: bool,
     pub steam_appid: Option<u32>,
 
@@ -71,6 +73,7 @@ impl Default for Handler {
 
             pause_between_starts: None,
 
+            use_mangohud: false,
             use_goldberg: false,
             steam_appid: None,
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -172,6 +172,9 @@ pub fn launch_cmds(
         }
 
         // Gamescope args
+        if h.use_mangohud {
+            cmd.arg("--mangoapp");
+        }
         cmd.args([
             "-W",
             &instance.width.to_string(),


### PR DESCRIPTION
Adds a toggle for mango hud in the handler settings. Allows the viewing of game performance and bypasses the issue of steams big picture performance overlay flickering