### PR TITLE
Add deps patch to main build to fix gamescope or any other deps

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -83,6 +83,15 @@ macro_rules! build_println {
     };
 }
 
+#[allow(dead_code)]
+fn apply_patches(deps_dir: &std::path::Path) {
+    let mut git_apply = std::process::Command::new("git");
+    git_apply.args(["apply", &deps_dir.join("deps.patch").to_string_lossy()]);
+    let _ = git_apply.spawn().map_err(|e| {
+        build_println!("Failed to git apply the patches we have for our deps, this is most likely not a real error: {:?} - {:?}", git_apply.get_program().to_string_lossy(), e);
+    });
+}
+
 fn main() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let deps_dir = root.join("deps/");
@@ -131,6 +140,8 @@ fn main() {
 
 #[cfg(feature = "build_gamescope")]
 fn build_gamescope(deps_dir: &Path) {
+    apply_patches(deps_dir); // Apply our own custom fixes for gamescope compilation
+    
     use std::process::Command;
 
     let gamescope_dir = deps_dir.join("gamescope");

--- a/deps/deps.patch
+++ b/deps/deps.patch
@@ -1,0 +1,13 @@
+diff --git a/deps/gamescope/subprojects/wlroots/backend/libinput/switch.c b/deps/gamescope/subprojects/wlroots/backend/libinput/switch.c
+index abeec86d..58edf684 100644
+--- a/deps/gamescope/subprojects/wlroots/backend/libinput/switch.c
++++ b/deps/gamescope/subprojects/wlroots/backend/libinput/switch.c
+@@ -36,6 +36,8 @@ void handle_switch_toggle(struct libinput_event *event,
+ 	case LIBINPUT_SWITCH_TABLET_MODE:
+ 		wlr_event.switch_type = WLR_SWITCH_TYPE_TABLET_MODE;
+ 		break;
++	default:
++		break;
+ 	}
+ 	switch (libinput_event_switch_get_switch_state(sevent)) {
+ 	case LIBINPUT_SWITCH_STATE_OFF:


### PR DESCRIPTION
Adds a simple .patch that is applied to the deps directory when building (currenly only with --build_gamescope as the only dep).

This allows for patching of gamescope files that are not feasible to patch in the upstream versions, here fixing a libinput update bug in wlroots that would require 2 extra repos being created to allow modification of a single file.

Changes in this file should not modify the actual functionality of the code, only make it easier to build or fix partydeck only bugs that cant be done in the main gamescope repo.