### PR TITLE
feat: add frame limiting and set gamescope refresh rate

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -427,6 +427,7 @@ impl PartyApp {
 
         let instances = self.instances.clone();
         let dev_infos: Vec<DeviceInfo> = self.input_devices.iter().map(|p| p.info()).collect();
+        let monitors = self.monitors.clone();
 
         let cfg = self.options.clone();
         let _ = save_cfg(&cfg);
@@ -451,7 +452,7 @@ impl PartyApp {
                     msg("Failed mounting game directories", &format!("{err}"));
                     return;
                 }
-                if let Err(err) = launch_game(&handler, &dev_infos, &instances, &cfg) {
+                if let Err(err) = launch_game(&handler, &dev_infos, &instances, &cfg, &monitors) {
                     println!("[partydeck] Error launching instances: {}", err);
                     msg("Launch Error", &format!("{err}"));
                 }

--- a/src/app/app_pages.rs
+++ b/src/app/app_pages.rs
@@ -201,6 +201,30 @@ impl PartyApp {
             ui.checkbox(&mut h.use_mangohud, "Enable MangoHud");
         });
 
+        ui.horizontal(|ui| {
+            ui.label("Frame limit override:");
+            // 0 = use global, 1 = disabled, 2 = custom
+            let mut mode: u8 = match h.frame_limit_override {
+                None => 0,
+                Some(0) => 1,
+                Some(_) => 2,
+            };
+            if ui.selectable_value(&mut mode, 0, "Use global").changed() {
+                h.frame_limit_override = None;
+            }
+            if ui.selectable_value(&mut mode, 1, "Disabled").changed() {
+                h.frame_limit_override = Some(0);
+            }
+            if ui.selectable_value(&mut mode, 2, "Custom").changed() {
+                h.frame_limit_override = Some(60);
+            }
+            if mode == 2 {
+                let limit = h.frame_limit_override.get_or_insert(60);
+                if *limit == 0 { *limit = 60; }
+                ui.add(egui::DragValue::new(limit).range(20..=360).suffix(" fps"));
+            }
+        });
+
         h.steam_appid = match &self.installed_steamapps[selected_index] {
             Some(app) => Some(app.app_id),
             None => None,
@@ -650,6 +674,53 @@ impl PartyApp {
         }
         if gamescope_force_grab_cursor_check.hovered() {
             self.infotext = "Sets the \"--force-grab-cursor\" flag in Gamescope. This keeps the cursor within the Gamescope window. If unsure, leave this unchecked.".to_string();
+        }
+
+        ui.separator();
+
+        ui.horizontal(|ui| {
+            let fl_label = ui.label("Frame limit:");
+            let mut enabled = self.options.frame_limit > 0;
+            if ui.checkbox(&mut enabled, "").changed() {
+                self.options.frame_limit = if enabled { 60 } else { 0 };
+                if enabled {
+                    msg(
+                        "Frame Limiter Notice",
+                        "If launching PartyDeck through Steam Big Picture Mode, make sure Steam's frame limiter is disabled. Otherwise there will be double frame limiting and potentially worse frame times.",
+                    );
+                }
+            }
+            if enabled {
+                ui.add(egui::DragValue::new(&mut self.options.frame_limit)
+                    .range(20..=360).suffix(" fps"));
+            } else {
+                ui.weak("Off");
+            }
+            if fl_label.hovered() {
+                self.infotext = "DEFAULT: Off\n\nSets a target frame rate limit.".to_string();
+            }
+        });
+
+        if self.options.frame_limit > 0 {
+            ui.horizontal(|ui| {
+                ui.label("MangoHud mode:");
+                let r1 = ui.radio_value(
+                    &mut self.options.mangohud_limit_mode,
+                    MangoHudLimitMode::Early,
+                    "Early",
+                );
+                let r2 = ui.radio_value(
+                    &mut self.options.mangohud_limit_mode,
+                    MangoHudLimitMode::Late,
+                    "Late",
+                );
+                if r1.hovered() {
+                    self.infotext = "DEFAULT: Early\n\nWaits before presenting each frame. Produces the flattest, most consistent frame times. Adds small amount of input latency.".to_string();
+                }
+                if r2.hovered() {
+                    self.infotext = "Waits after presenting each frame. Lower input latency than Early mode, but frame times will be less consistent.".to_string();
+                }
+            });
         }
     }
 }

--- a/src/app/app_pages.rs
+++ b/src/app/app_pages.rs
@@ -662,6 +662,10 @@ impl PartyApp {
             &mut self.options.gamescope_force_grab_cursor,
             "Force grab cursor for Gamescope",
         );
+        let gamescope_auto_set_refresh_rate_check = ui.checkbox(
+            &mut self.options.gamescope_auto_set_refresh_rate,
+            "Automatically set Gamescope refresh rate",
+        );
 
         if gamescope_lowres_fix_check.hovered() {
             self.infotext = "Many games have graphical problems or even crash when running at resolutions below 600p. If this is enabled, any instances below 600p will automatically be resized before launching.".to_string();
@@ -674,6 +678,9 @@ impl PartyApp {
         }
         if gamescope_force_grab_cursor_check.hovered() {
             self.infotext = "Sets the \"--force-grab-cursor\" flag in Gamescope. This keeps the cursor within the Gamescope window. If unsure, leave this unchecked.".to_string();
+        }
+        if gamescope_auto_set_refresh_rate_check.hovered() {
+            self.infotext = "DEFAULT: Disabled\n\nAutomatically sets Gamescope's refresh rate to match the selected display. Use this if your games are not picking up the correct display refresh rate.".to_string();
         }
 
         ui.separator();

--- a/src/app/app_pages.rs
+++ b/src/app/app_pages.rs
@@ -693,7 +693,8 @@ impl PartyApp {
                 if enabled {
                     msg(
                         "Frame Limiter Notice",
-                        "If launching PartyDeck through Steam Big Picture Mode, make sure Steam's frame limiter is disabled. Otherwise there will be double frame limiting and potentially worse frame times.",
+                        "If launching PartyDeck through Steam Big Picture Mode, make sure Steam's frame limiter is disabled. Otherwise there will be double frame limiting and potentially worse frame times.
+                        \n\nFrame limiting injects MangoHud into the game process. This may not work with some opengl games or games that override LD_PRELOAD",
                     );
                 }
             }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -35,6 +35,8 @@ pub struct PartyConfig {
     pub gamescope_sdl_backend: bool,
     #[serde(default)]
     pub gamescope_force_grab_cursor: bool,
+    #[serde(default)]
+    pub gamescope_auto_set_refresh_rate: bool,
     #[serde(default = "default_true")]
     pub kbm_support: bool,
     #[serde(default)]
@@ -68,6 +70,7 @@ impl Default for PartyConfig {
             gamescope_fix_lowres: true,
             gamescope_sdl_backend: true,
             gamescope_force_grab_cursor: false,
+            gamescope_auto_set_refresh_rate: false,
             kbm_support: true,
             proton_version: "".to_string(),
             proton_separate_pfxs: true,

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -7,6 +7,13 @@ use std::io::BufReader;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Default)]
+pub enum MangoHudLimitMode {
+    #[default]
+    Early,
+    Late,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Default)]
 pub enum PadFilterType {
     All,
     #[default]
@@ -48,6 +55,10 @@ pub struct PartyConfig {
     pub disable_mount_gamedirs: bool,
     #[serde(default)]
     pub check_for_updates: bool,
+    #[serde(default)]
+    pub frame_limit: u32,
+    #[serde(default)]
+    pub mangohud_limit_mode: MangoHudLimitMode,
 }
 
 impl Default for PartyConfig {
@@ -67,6 +78,8 @@ impl Default for PartyConfig {
             profile_unique_dirs: true,
             disable_mount_gamedirs: false,
             check_for_updates: true,
+            frame_limit: 0,
+            mangohud_limit_mode: MangoHudLimitMode::Early,
         }
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,5 +4,6 @@ mod app_panels;
 mod config;
 
 pub use app::PartyApp;
+pub use config::MangoHudLimitMode;
 pub use config::PadFilterType;
 pub use config::PartyConfig;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -46,6 +46,8 @@ pub struct Handler {
 
     #[serde(default)]
     pub use_mangohud: bool,
+    #[serde(default)]
+    pub frame_limit_override: Option<u32>,
     pub use_goldberg: bool,
     pub steam_appid: Option<u32>,
 
@@ -74,6 +76,7 @@ impl Default for Handler {
             pause_between_starts: None,
 
             use_mangohud: false,
+            frame_limit_override: None,
             use_goldberg: false,
             steam_appid: None,
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -184,32 +184,13 @@ pub fn launch_cmds(
             }
         }
 
-        let mut mangohud_config: Option<String> = None;
         let frame_limit = h.frame_limit_override.unwrap_or(cfg.frame_limit);
-
         let mangohud_framelimit = frame_limit > 0;
-        let use_mangohud = h.use_mangohud || mangohud_framelimit;
 
-        if use_mangohud {
-            let mut config_parts: Vec<String> = Vec::new();
-
-            if mangohud_framelimit {
-                let method = match cfg.mangohud_limit_mode {
-                    MangoHudLimitMode::Early => "early",
-                    MangoHudLimitMode::Late => "late",
-                };
-                config_parts.push(format!("fps_limit={}", frame_limit));
-                config_parts.push(format!("fps_limit_method={}", method));
-            }
-
-            if !h.use_mangohud {
-                config_parts.push("no_display".to_string());
-            }
-
-            if !config_parts.is_empty() {
-                mangohud_config = Some(config_parts.join(","));
-            }
+        if h.use_mangohud {
+            cmd.arg("--mangoapp");
         }
+
         cmd.args([
             "-W",
             &instance.width.to_string(),
@@ -267,12 +248,18 @@ pub fn launch_cmds(
         cmd.args(["--dev-bind", "/", "/"]);
         cmd.args(["--tmpfs", "/tmp"]);
 
-        if use_mangohud {
+        if mangohud_framelimit {
+            println!("[partydeck] Frame limiting enabled");
+            let method = match cfg.mangohud_limit_mode {
+                MangoHudLimitMode::Early => "early",
+                MangoHudLimitMode::Late => "late",
+            };
+            let mangohud_config = format!("fps_limit={},fps_limit_method={},no_display", frame_limit, method);
             cmd.args(["--setenv", "MANGOHUD", "1"]);
+            cmd.args(["--setenv", "LD_PRELOAD", "/usr/$LIB/mangohud/libMangoHud_shim.so"]);
+            cmd.args(["--setenv", "MANGOHUD_CONFIG", &mangohud_config]);
         }
-        if let Some(ref mangohud_config) = mangohud_config {
-            cmd.args(["--setenv", "MANGOHUD_CONFIG", mangohud_config]);
-        }
+    
         // Mask out any gamepads that aren't this player's
         for (d, dev) in input_devices.iter().enumerate() {
             if !dev.enabled

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -216,12 +216,14 @@ pub fn launch_cmds(
             "-H",
             &instance.height.to_string(),
         ]);
-        let refresh = if cfg.gamescope_sdl_backend {
-            monitors[instance.monitor].refresh_rate()
-        } else {
-            monitors[0].refresh_rate()
-        };
-        cmd.args(["-r", &refresh.to_string()]);
+        if cfg.gamescope_auto_set_refresh_rate {
+            let refresh = if cfg.gamescope_sdl_backend {
+                monitors[instance.monitor].refresh_rate()
+            } else {
+                monitors[0].refresh_rate()
+            };
+            cmd.args(["-r", &refresh.to_string()]);
+        }
         if cfg.gamescope_force_grab_cursor {
             cmd.arg("--force-grab-cursor");
         }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,10 +1,11 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::app::{PartyConfig, PadFilterType};
+use crate::app::{PartyConfig, PadFilterType, MangoHudLimitMode};
 use crate::handler::*;
 use crate::input::*;
 use crate::instance::*;
+use crate::monitor::Monitor;
 use crate::paths::*;
 use crate::profiles::{create_profile, create_profile_gamesave};
 use crate::util::*;
@@ -35,8 +36,9 @@ pub fn launch_game(
     input_devices: &[DeviceInfo],
     instances: &Vec<Instance>,
     cfg: &PartyConfig,
+    monitors: &[Monitor],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let new_cmds = launch_cmds(h, input_devices, instances, cfg)?;
+    let new_cmds = launch_cmds(h, input_devices, instances, cfg, monitors)?;
     print_launch_cmds(&new_cmds);
 
     if cfg.enable_kwin_script {
@@ -80,6 +82,7 @@ pub fn launch_cmds(
     input_devices: &[DeviceInfo],
     instances: &Vec<Instance>,
     cfg: &PartyConfig,
+    monitors: &[Monitor],
 ) -> Result<Vec<std::process::Command>, Box<dyn std::error::Error>> {
     let win = h.win();
     let exec = Path::new(&h.exec);
@@ -181,9 +184,31 @@ pub fn launch_cmds(
             }
         }
 
-        // Gamescope args
-        if h.use_mangohud {
-            cmd.arg("--mangoapp");
+        let mut mangohud_config: Option<String> = None;
+        let frame_limit = h.frame_limit_override.unwrap_or(cfg.frame_limit);
+
+        let mangohud_framelimit = frame_limit > 0;
+        let use_mangohud = h.use_mangohud || mangohud_framelimit;
+
+        if use_mangohud {
+            let mut config_parts: Vec<String> = Vec::new();
+
+            if mangohud_framelimit {
+                let method = match cfg.mangohud_limit_mode {
+                    MangoHudLimitMode::Early => "early",
+                    MangoHudLimitMode::Late => "late",
+                };
+                config_parts.push(format!("fps_limit={}", frame_limit));
+                config_parts.push(format!("fps_limit_method={}", method));
+            }
+
+            if !h.use_mangohud {
+                config_parts.push("no_display".to_string());
+            }
+
+            if !config_parts.is_empty() {
+                mangohud_config = Some(config_parts.join(","));
+            }
         }
         cmd.args([
             "-W",
@@ -191,6 +216,12 @@ pub fn launch_cmds(
             "-H",
             &instance.height.to_string(),
         ]);
+        let refresh = if cfg.gamescope_sdl_backend {
+            monitors[instance.monitor].refresh_rate()
+        } else {
+            monitors[0].refresh_rate()
+        };
+        cmd.args(["-r", &refresh.to_string()]);
         if cfg.gamescope_force_grab_cursor {
             cmd.arg("--force-grab-cursor");
         }
@@ -233,6 +264,13 @@ pub fn launch_cmds(
         cmd.arg("--die-with-parent");
         cmd.args(["--dev-bind", "/", "/"]);
         cmd.args(["--tmpfs", "/tmp"]);
+
+        if use_mangohud {
+            cmd.args(["--setenv", "MANGOHUD", "1"]);
+        }
+        if let Some(ref mangohud_config) = mangohud_config {
+            cmd.args(["--setenv", "MANGOHUD_CONFIG", mangohud_config]);
+        }
         // Mask out any gamepads that aren't this player's
         for (d, dev) in input_devices.iter().enumerate() {
             if !dev.enabled

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,11 @@ fn main() -> eframe::Result {
     println!("[partydeck] Monitors detected:");
     for monitor in &monitors {
         println!(
-            "[partydeck] {} ({}x{})",
+            "[partydeck] {} ({}x{} @ {}Hz)",
             monitor.name(),
             monitor.width(),
-            monitor.height()
+            monitor.height(),
+            monitor.refresh_rate()
         );
     }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,5 +1,6 @@
 use x11rb::connection::Connection;
 use x11rb::protocol::randr::ConnectionExt as _;
+use x11rb::protocol::randr::ModeFlag;
 
 
 #[derive(Clone)]
@@ -7,6 +8,7 @@ pub struct Monitor {
     name: String,
     width: u32,
     height: u32,
+    refresh_rate: u32,
 }
 
 impl Monitor {
@@ -20,6 +22,10 @@ impl Monitor {
 
     pub fn height(&self) -> u32 {
         self.height
+    }
+
+    pub fn refresh_rate(&self) -> u32 {
+        self.refresh_rate
     }
 }
 
@@ -56,10 +62,29 @@ fn get_monitors_x11() -> Result<Vec<Monitor>, Box<dyn std::error::Error>> {
 
         let name = String::from_utf8_lossy(&info.name).to_string();
 
+        let mode_info = res.modes.iter().find(|m| m.id == crtc.mode);
+        let refresh_rate = match mode_info {
+            Some(m) if m.dot_clock > 0 && m.htotal > 0 && m.vtotal > 0 => {
+                let mut numerator = m.dot_clock as u64;
+                let mut denominator = m.htotal as u64 * m.vtotal as u64;
+
+                if m.mode_flags.contains(ModeFlag::INTERLACE) {
+                    numerator *= 2;
+                }
+                if m.mode_flags.contains(ModeFlag::DOUBLE_SCAN) {
+                    denominator *= 2;
+                }
+
+                ((numerator + denominator / 2) / denominator) as u32
+            }
+            _ => 60,
+        };
+
         let monitor = Monitor {
             name: name.clone(),
             width: crtc.width.into(),
             height: crtc.height.into(),
+            refresh_rate,
         };
 
         if *output == primary {
@@ -82,7 +107,7 @@ pub fn get_monitors_errorless() -> Vec<Monitor> {
 
     if monitors.len() == 0 { // Quick patch for those who have no x11 visable monitors, so we dont just panic.
         println!("[PARTYDECK] Failed to get monitors; using assumed 1920x1080");
-        monitors.push(Monitor {name: "Partydeck Virtual Monitor".to_string(), width: 1920, height: 1080});
+        monitors.push(Monitor {name: "Partydeck Virtual Monitor".to_string(), width: 1920, height: 1080, refresh_rate: 60});
     }
 
     return monitors;


### PR DESCRIPTION
Adds a configurable frame limiter. there is global options and override options per handler.

refresh rate can be set through the -r arg on gamescope, this fixes an issue where in some games because of the timing where game scope auto sets the refresh rate, the game does not pickup the correct number and defaults to 60fps