### PR TITLE
fix: kwin scaling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod util;
 
 use crate::app::*;
 use crate::handler::Handler;
-use crate::monitor::get_monitors_errorless;
+use crate::monitor::{get_monitors_errorless, get_x11_dpi_scale};
 use crate::paths::PATH_PARTY;
 use crate::profiles::remove_guest_profiles;
 use crate::util::*;
@@ -47,6 +47,8 @@ fn main() -> eframe::Result {
         cmd.arg("--height");
         cmd.arg(h.to_string());
         cmd.arg("--exit-with-session");
+        cmd.env("PARTYDECK_SCREEN_WIDTH", w.to_string());
+        cmd.env("PARTYDECK_SCREEN_HEIGHT", h.to_string());
         let args_string = args
             .iter()
             .map(|arg| format!("\"{}\"", arg))
@@ -109,7 +111,7 @@ fn main() -> eframe::Result {
     let scrheight = monitors[0].height();
 
     let scale = match fullscreen {
-        true => scrheight as f32 / 560.0,
+        true => scrheight as f32 / 560.0 / get_x11_dpi_scale(),
         false => 1.3,
     };
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -92,7 +92,7 @@ pub fn get_x11_dpi_scale() -> f32 {
     for line in rm_string.lines() {
         if let Some(rest) = line.strip_prefix("Xft.dpi:") {
             if let Ok(dpi) = rest.trim().parse::<f32>() {
-                return dpi / 96.0;
+                if dpi > 0.0 { return dpi / 96.0; }
             }
         }
     }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -73,6 +73,33 @@ fn get_monitors_x11() -> Result<Vec<Monitor>, Box<dyn std::error::Error>> {
     Ok(monitors)
 }
 
+pub fn get_x11_dpi_scale() -> f32 {
+    use x11rb::protocol::xproto::{AtomEnum, ConnectionExt as _};
+
+    let Ok((conn, screen_num)) = x11rb::connect(None) else {
+        return 1.0;
+    };
+    let root = conn.setup().roots[screen_num].root;
+
+    let Ok(cookie) = conn.get_property(false, root, AtomEnum::RESOURCE_MANAGER, AtomEnum::STRING, 0, 65536) else {
+        return 1.0;
+    };
+    let Ok(reply) = cookie.reply() else {
+        return 1.0;
+    };
+
+    let rm_string = String::from_utf8_lossy(&reply.value);
+    for line in rm_string.lines() {
+        if let Some(rest) = line.strip_prefix("Xft.dpi:") {
+            if let Ok(dpi) = rest.trim().parse::<f32>() {
+                return dpi / 96.0;
+            }
+        }
+    }
+
+    1.0
+}
+
 pub fn get_monitors_errorless() -> Vec<Monitor> {
     let mut monitors = Vec::new();
 
@@ -85,5 +112,12 @@ pub fn get_monitors_errorless() -> Vec<Monitor> {
         monitors.push(Monitor {name: "Partydeck Virtual Monitor".to_string(), width: 1920, height: 1080});
     }
 
-    return monitors;
+    if let (Ok(w), Ok(h)) = (std::env::var("PARTYDECK_SCREEN_WIDTH"), std::env::var("PARTYDECK_SCREEN_HEIGHT")) {
+        if let (Ok(w), Ok(h)) = (w.parse::<u32>(), h.parse::<u32>()) {
+            monitors[0].width = w;
+            monitors[0].height = h;
+        }
+    }
+
+    monitors
 }


### PR DESCRIPTION
this pr fixes an issue when using --kwin, the compositor will inherit the deskop kde scaling and this causes the resolutions on the nested kwin compositor to be incorrect and multiply by the desktop scaling. this pr gets the real screen res before kwin is relaunched and passes it through and uses that instead.

