### PR TITLE
Per-instance render resolution, KWin multi-monitor placement, and audio sinks

### DIFF
--- a/res/splitscreen_kwin.js
+++ b/res/splitscreen_kwin.js
@@ -1,106 +1,77 @@
-const x = [
-  [],
-  [0],
-  [0, 0],
-  [0, 0, 0.5],
-  [0, 0.5, 0, 0.5]
-]
+// Loaded by PartyDeck. Two tokens are replaced at launch:
+//   PARTYDECK_ASSIGNMENTS      -> array mapping instance index -> screen index,
+//                                 e.g. [0, 1].
+//   PARTYDECK_USE_ASSIGNMENTS  -> true  : place each instance on its assigned
+//                                         screen (multi-monitor);
+//                                 false : classic splitscreen — ignore
+//                                         assignments and split whatever screen
+//                                         KWin opened each window on.
+// Instances sharing a screen are split (horizontal: stacked top/bottom).
+const assignments = PARTYDECK_ASSIGNMENTS;
+const useAssignments = PARTYDECK_USE_ASSIGNMENTS;
 
-const y = [
-  [],
-  [0],
-  [0, 0.5],
-  [0, 0.5, 0.5],
-  [0, 0, 0.5, 0.5]
-]
+const x = [[], [0], [0, 0], [0, 0, 0.5], [0, 0.5, 0, 0.5]];
+const y = [[], [0], [0, 0.5], [0, 0.5, 0.5], [0, 0, 0.5, 0.5]];
+const width = [[], [1], [1, 1], [1, 0.5, 0.5], [0.5, 0.5, 0.5, 0.5]];
+const height = [[], [1], [0.5, 0.5], [0.5, 0.5, 0.5], [0.5, 0.5, 0.5, 0.5]];
 
-const width = [
-  [],
-  [1],
-  [1, 1],
-  [1, 0.5, 0.5],
-  [0.5, 0.5, 0.5, 0.5]
-]
-
-const height = [
-  [],
-  [1],
-  [0.5, 0.5],
-  [0.5, 0.5, 0.5],
-  [0.5, 0.5, 0.5, 0.5]
-]
-
-function getGamescopeClients() {
-  var allClients = workspace.windowList();
-  var gamescopeClients = [];
-
-  for (var i = 0; i < allClients.length; i++) {
-    if (
-      allClients[i].resourceClass == "gamescope" ||
-      allClients[i].resourceClass == "gamescope-kbm"
-    ) {
-      gamescopeClients.push(allClients[i]);
-    }
+function gamescopeClients() {
+  const all = workspace.windowList();
+  const out = [];
+  for (let i = 0; i < all.length; i++) {
+    const rc = all[i].resourceClass;
+    if (rc == "gamescope" || rc == "gamescope-kbm") out.push(all[i]);
   }
-  return gamescopeClients;
+  return out;
 }
 
-function numGamescopeClientsInOutput(output) {
-  var gamescopeClients = getGamescopeClients();
-  var count = 0;
-  for (var i = 0; i < gamescopeClients.length; i++) {
-    if (gamescopeClients[i].output == output) {
-      count++;
-    }
+// The screen index a given client should live on. Multi-monitor mode honors the
+// baked-in per-instance assignment; classic mode uses the screen KWin already
+// placed the window on (so it just splits the current screen).
+function screenIndexFor(clients, i, screens) {
+  if (useAssignments) {
+    return i < assignments.length ? assignments[i] : 0;
   }
-  return count;
+  const out = clients[i].output;
+  for (let s = 0; s < screens.length; s++) {
+    if (screens[s] === out) return s;
+  }
+  return 0;
 }
 
-function gamescopeAboveBelow() {
-  var gamescopeClients = getGamescopeClients();
-  for (var i = 0; i < gamescopeClients.length; i++) {
-    if (
-      workspace.activeWindow.resourceClass == "gamescope" ||
-      workspace.activeWindow.resourceClass == "gamescope-kbm"
-    ) {
-      gamescopeClients[i].keepAbove = true;
-    } else {
-      gamescopeClients[i].keepAbove = false;
-    }
-  }
-}
+// Re-place every gamescope window on each event (robust to windows whose class
+// isn't set the instant they're added). Window i (in list order) == instance i.
+function layout() {
+  const clients = gamescopeClients();
+  const screens = workspace.screens;
 
-function gamescopeSplitscreen() {
-  var gamescopeClients = getGamescopeClients();
-
-  var screenMap = new Map();
-  var screens = workspace.screens;
-  for (var j = 0; j < screens.length; j++) {
-    screenMap.set(screens[j], 0);
+  const total = {};
+  for (let i = 0; i < clients.length; i++) {
+    const s = screenIndexFor(clients, i, screens);
+    total[s] = (total[s] || 0) + 1;
   }
 
-  for (var i = 0; i < gamescopeClients.length; i++) {
-    var monitor = gamescopeClients[i].output;
-    var monitorX = monitor.geometry.x;
-    var monitorY = monitor.geometry.y;
-    var monitorWidth = monitor.geometry.width;
-    var monitorHeight = monitor.geometry.height;
-
-    var playerCount = numGamescopeClientsInOutput(monitor);
-    var playerIndex = screenMap.get(monitor);
-    screenMap.set(monitor, playerIndex + 1);
-
-    gamescopeClients[i].noBorder = true;
-    gamescopeClients[i].frameGeometry = {
-      x: monitorX + x[playerCount][playerIndex] * monitorWidth,
-      y: monitorY + y[playerCount][playerIndex] * monitorHeight,
-      width: monitorWidth * width[playerCount][playerIndex],
-      height: monitorHeight * height[playerCount][playerIndex],
+  const slot = {};
+  for (let i = 0; i < clients.length; i++) {
+    const s = screenIndexFor(clients, i, screens);
+    if (slot[s] === undefined) slot[s] = 0;
+    const idx = slot[s];
+    slot[s] += 1;
+    const c = total[s];
+    const screen = s >= 0 && s < screens.length ? screens[s] : screens[0];
+    if (!screen) continue;
+    const g = screen.geometry;
+    const w = clients[i];
+    w.noBorder = true;
+    w.keepAbove = true;
+    w.frameGeometry = {
+      x: g.x + x[c][idx] * g.width,
+      y: g.y + y[c][idx] * g.height,
+      width: g.width * width[c][idx],
+      height: g.height * height[c][idx],
     };
   }
-  gamescopeAboveBelow();
 }
 
-workspace.windowAdded.connect(gamescopeSplitscreen);
-workspace.windowRemoved.connect(gamescopeSplitscreen);
-workspace.windowActivated.connect(gamescopeAboveBelow);
+workspace.windowAdded.connect(layout);
+workspace.windowRemoved.connect(layout);

--- a/res/splitscreen_kwin_vertical.js
+++ b/res/splitscreen_kwin_vertical.js
@@ -1,106 +1,77 @@
-const x = [
-  [],
-  [0],
-  [0, 0.5],
-  [0, 0, 0.5],
-  [0, 0.5, 0, 0.5]
-]
+// Loaded by PartyDeck. Two tokens are replaced at launch:
+//   PARTYDECK_ASSIGNMENTS      -> array mapping instance index -> screen index,
+//                                 e.g. [0, 1].
+//   PARTYDECK_USE_ASSIGNMENTS  -> true  : place each instance on its assigned
+//                                         screen (multi-monitor);
+//                                 false : classic splitscreen — ignore
+//                                         assignments and split whatever screen
+//                                         KWin opened each window on.
+// Instances sharing a screen are split (vertical: side by side).
+const assignments = PARTYDECK_ASSIGNMENTS;
+const useAssignments = PARTYDECK_USE_ASSIGNMENTS;
 
-const y = [
-  [],
-  [0],
-  [0, 0],
-  [0, 0.5, 0.5],
-  [0, 0, 0.5, 0.5]
-]
+const x = [[], [0], [0, 0.5], [0, 0, 0.5], [0, 0.5, 0, 0.5]];
+const y = [[], [0], [0, 0], [0, 0.5, 0.5], [0, 0, 0.5, 0.5]];
+const width = [[], [1], [0.5, 0.5], [1, 0.5, 0.5], [0.5, 0.5, 0.5, 0.5]];
+const height = [[], [1], [1, 1], [0.5, 0.5, 0.5], [0.5, 0.5, 0.5, 0.5]];
 
-const width = [
-  [],
-  [1],
-  [0.5, 0.5],
-  [1, 0.5, 0.5],
-  [0.5, 0.5, 0.5, 0.5]
-]
-
-const height = [
-  [],
-  [1],
-  [1, 1],
-  [0.5, 0.5, 0.5],
-  [0.5, 0.5, 0.5, 0.5]
-]
-
-function getGamescopeClients() {
-  var allClients = workspace.windowList();
-  var gamescopeClients = [];
-
-  for (var i = 0; i < allClients.length; i++) {
-    if (
-      allClients[i].resourceClass == "gamescope" ||
-      allClients[i].resourceClass == "gamescope-kbm"
-    ) {
-      gamescopeClients.push(allClients[i]);
-    }
+function gamescopeClients() {
+  const all = workspace.windowList();
+  const out = [];
+  for (let i = 0; i < all.length; i++) {
+    const rc = all[i].resourceClass;
+    if (rc == "gamescope" || rc == "gamescope-kbm") out.push(all[i]);
   }
-  return gamescopeClients;
+  return out;
 }
 
-function numGamescopeClientsInOutput(output) {
-  var gamescopeClients = getGamescopeClients();
-  var count = 0;
-  for (var i = 0; i < gamescopeClients.length; i++) {
-    if (gamescopeClients[i].output == output) {
-      count++;
-    }
+// The screen index a given client should live on. Multi-monitor mode honors the
+// baked-in per-instance assignment; classic mode uses the screen KWin already
+// placed the window on (so it just splits the current screen).
+function screenIndexFor(clients, i, screens) {
+  if (useAssignments) {
+    return i < assignments.length ? assignments[i] : 0;
   }
-  return count;
+  const out = clients[i].output;
+  for (let s = 0; s < screens.length; s++) {
+    if (screens[s] === out) return s;
+  }
+  return 0;
 }
 
-function gamescopeAboveBelow() {
-  var gamescopeClients = getGamescopeClients();
-  for (var i = 0; i < gamescopeClients.length; i++) {
-    if (
-      workspace.activeWindow.resourceClass == "gamescope" ||
-      workspace.activeWindow.resourceClass == "gamescope-kbm"
-    ) {
-      gamescopeClients[i].keepAbove = true;
-    } else {
-      gamescopeClients[i].keepAbove = false;
-    }
-  }
-}
+// Re-place every gamescope window on each event (robust to windows whose class
+// isn't set the instant they're added). Window i (in list order) == instance i.
+function layout() {
+  const clients = gamescopeClients();
+  const screens = workspace.screens;
 
-function gamescopeSplitscreen() {
-  var gamescopeClients = getGamescopeClients();
-
-  var screenMap = new Map();
-  var screens = workspace.screens;
-  for (var j = 0; j < screens.length; j++) {
-    screenMap.set(screens[j], 0);
+  const total = {};
+  for (let i = 0; i < clients.length; i++) {
+    const s = screenIndexFor(clients, i, screens);
+    total[s] = (total[s] || 0) + 1;
   }
 
-  for (var i = 0; i < gamescopeClients.length; i++) {
-    var monitor = gamescopeClients[i].output;
-    var monitorX = monitor.geometry.x;
-    var monitorY = monitor.geometry.y;
-    var monitorWidth = monitor.geometry.width;
-    var monitorHeight = monitor.geometry.height;
-
-    var playerCount = numGamescopeClientsInOutput(monitor);
-    var playerIndex = screenMap.get(monitor);
-    screenMap.set(monitor, playerIndex + 1);
-
-    gamescopeClients[i].noBorder = true;
-    gamescopeClients[i].frameGeometry = {
-      x: monitorX + x[playerCount][playerIndex] * monitorWidth,
-      y: monitorY + y[playerCount][playerIndex] * monitorHeight,
-      width: monitorWidth * width[playerCount][playerIndex],
-      height: monitorHeight * height[playerCount][playerIndex],
+  const slot = {};
+  for (let i = 0; i < clients.length; i++) {
+    const s = screenIndexFor(clients, i, screens);
+    if (slot[s] === undefined) slot[s] = 0;
+    const idx = slot[s];
+    slot[s] += 1;
+    const c = total[s];
+    const screen = s >= 0 && s < screens.length ? screens[s] : screens[0];
+    if (!screen) continue;
+    const g = screen.geometry;
+    const w = clients[i];
+    w.noBorder = true;
+    w.keepAbove = true;
+    w.frameGeometry = {
+      x: g.x + x[c][idx] * g.width,
+      y: g.y + y[c][idx] * g.height,
+      width: g.width * width[c][idx],
+      height: g.height * height[c][idx],
     };
   }
-  gamescopeAboveBelow();
 }
 
-workspace.windowAdded.connect(gamescopeSplitscreen);
-workspace.windowRemoved.connect(gamescopeSplitscreen);
-workspace.windowActivated.connect(gamescopeAboveBelow);
+workspace.windowAdded.connect(layout);
+workspace.windowRemoved.connect(layout);

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -39,6 +39,7 @@ pub struct PartyApp {
     pub infotext: String,
 
     pub monitors: Vec<Monitor>,
+    pub audio_sinks: Vec<String>,
     pub input_devices: Vec<InputDevice>,
     pub instances: Vec<Instance>,
     pub instance_add_dev: Option<usize>,
@@ -82,6 +83,7 @@ impl PartyApp {
             settings_page: SettingsPage::General,
             infotext: String::new(),
             monitors,
+            audio_sinks: get_audio_sinks(),
             input_devices,
             instances: Vec::new(),
             instance_add_dev: None,
@@ -307,13 +309,23 @@ impl PartyApp {
                             }
                         }
                         None => {
+                            // Default each new instance onto its own monitor
+                            // (instance 0 -> monitor 0, instance 1 -> monitor 1,
+                            // ...), capped to the available monitors. Still
+                            // overridable per-instance via the 🖵 dropdown.
+                            let mon = self
+                                .instances
+                                .len()
+                                .min(self.monitors.len().saturating_sub(1));
                             self.instances.push(Instance {
                                 devices: vec![i],
                                 profname: String::new(),
                                 profselection: 0,
-                                monitor: 0,
+                                monitor: mon,
+                                audio_sink: String::new(),
                                 width: 0,
                                 height: 0,
+                                res_override: None,
                             });
                         }
                     }
@@ -408,15 +420,9 @@ impl PartyApp {
     }
 
     pub fn prepare_game_launch(&mut self) {
-        if self.options.gamescope_sdl_backend {
-            set_instance_resolutions_multimonitor(
-                &mut self.instances,
-                &self.monitors,
-                &self.options,
-            );
-        } else {
-            set_instance_resolutions(&mut self.instances, &self.monitors[0], &self.options);
-        }
+        // Size each instance to its assigned monitor regardless of backend.
+        // (Single-monitor setups simply have every instance on monitor 0.)
+        set_instance_resolutions_multimonitor(&mut self.instances, &self.monitors, &self.options);
         set_instance_names(&mut self.instances, &self.profiles);
 
         let handler = if let Some(h) = self.handler_lite.clone() {

--- a/src/app/app_pages.rs
+++ b/src/app/app_pages.rs
@@ -335,6 +335,7 @@ impl PartyApp {
                     self.instances.clear();
                     self.input_devices = scan_input_devices(&self.options.pad_filter_type);
                     self.monitors = get_monitors_errorless();
+                    self.audio_sinks = get_audio_sinks();
                     self.profiles = scan_profiles(true);
                     self.instance_add_dev = None;
                     self.cur_page = MenuPage::Instances;
@@ -413,6 +414,7 @@ impl PartyApp {
         ui.separator();
 
         let mut devices_to_remove: Vec<(usize, usize)> = Vec::new();
+        let audio_sinks = self.audio_sinks.clone();
         for (i, instance) in &mut self.instances.iter_mut().enumerate() {
             ui.horizontal(|ui| {
                 ui.label(format!("{}", i + 1));
@@ -425,7 +427,7 @@ impl PartyApp {
                     |i| self.profiles[i].clone(),
                 );
 
-                if self.options.gamescope_sdl_backend {
+                if self.monitors.len() > 1 {
                     ui.label("🖵");
                     egui::ComboBox::from_id_salt(format!("monitors{i}")).show_index(
                         ui,
@@ -434,6 +436,52 @@ impl PartyApp {
                         |i| self.monitors[i].name(),
                     );
                 }
+
+                // Per-instance resolution override, as a monitor-icon toggle.
+                // Off = auto-size from the assigned monitor. Toggling on prefills
+                // that monitor's current resolution so it can be nudged (e.g.
+                // 16:10 panels).
+                let mut overridden = instance.res_override.is_some();
+                if ui
+                    .toggle_value(&mut overridden, "🖥")
+                    .on_hover_text(
+                        "Override render resolution — renders the game at this size and upscales it to fill the monitor.",
+                    )
+                    .changed()
+                {
+                    instance.res_override = if overridden {
+                        let mon = self
+                            .monitors
+                            .get(instance.monitor)
+                            .or_else(|| self.monitors.first());
+                        Some(match mon {
+                            Some(m) => (m.width(), m.height()),
+                            None => (1920, 1080),
+                        })
+                    } else {
+                        None
+                    };
+                }
+                if let Some((mut w, mut h)) = instance.res_override {
+                    ui.add(egui::DragValue::new(&mut w).range(320..=7680).speed(1));
+                    ui.label("×");
+                    ui.add(egui::DragValue::new(&mut h).range(240..=4320).speed(1));
+                    instance.res_override = Some((w, h));
+                }
+
+                ui.label("🔊");
+                egui::ComboBox::from_id_salt(format!("sink{i}"))
+                    .selected_text(if instance.audio_sink.is_empty() {
+                        "Default".to_string()
+                    } else {
+                        instance.audio_sink.clone()
+                    })
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut instance.audio_sink, String::new(), "Default");
+                        for sink in audio_sinks.iter() {
+                            ui.selectable_value(&mut instance.audio_sink, sink.clone(), sink);
+                        }
+                    });
 
                 if self.instance_add_dev == None {
                     let invitebtn = ui.add(
@@ -474,6 +522,29 @@ impl PartyApp {
             self.remove_device_instance(i, d);
         }
 
+        ui.horizontal(|ui| {
+            if ui.button("🔊 Create Virtual Sink").clicked() {
+                // Lowest free PartyDeck-N index, so removing a middle sink and
+                // re-creating doesn't collide with one that still exists.
+                let n = (1..)
+                    .find(|i| !self.audio_sinks.contains(&format!("PartyDeck-{i}")))
+                    .unwrap_or(1);
+                if let Err(e) = create_virtual_sink(&format!("PartyDeck-{n}")) {
+                    msg("Error", &format!("Couldn't create virtual sink: {e}"));
+                }
+                self.audio_sinks = get_audio_sinks();
+            }
+            if ui.button("Remove PartyDeck Sinks").clicked() {
+                if let Err(e) = remove_virtual_sinks("PartyDeck-") {
+                    msg("Error", &format!("Couldn't remove virtual sinks: {e}"));
+                }
+                self.audio_sinks = get_audio_sinks();
+            }
+            if ui.button("⟳ Refresh Sinks").clicked() {
+                self.audio_sinks = get_audio_sinks();
+            }
+        });
+
         if self.instances.len() > 0 {
             ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {
                 ui.horizontal(|ui| {
@@ -502,6 +573,14 @@ impl PartyApp {
         );
         if enable_kwin_script_check.hovered() {
             self.infotext = "DEFAULT: Enabled\n\n Resizes/repositions instances to fit the screen using a KWin script. If using a desktop environment or window manager other than KDE Plasma, uncheck this; note that you will need to manually resize and reposition the windows.".to_string();
+        }
+
+        let kwin_multimonitor_check = ui.checkbox(
+            &mut self.options.kwin_multimonitor,
+            "(KDE) Place each instance on its assigned monitor (multi-monitor)",
+        );
+        if kwin_multimonitor_check.hovered() {
+            self.infotext = "DEFAULT: Enabled\n\nWhen enabled, the KWin script places each instance on the monitor you assign it in the Instances page (multi-monitor). When disabled, it falls back to classic splitscreen: every window splits whichever single screen it opens on, ignoring monitor assignments. Only applies when the KWin script above is enabled.".to_string();
         }
 
         ui.horizontal(|ui| {

--- a/src/app/app_panels.rs
+++ b/src/app/app_panels.rs
@@ -66,6 +66,7 @@ impl PartyApp {
             if ui.button("🖵 🔄").clicked() {
                 self.instances.clear();
                 self.monitors = get_monitors_errorless();
+                self.audio_sinks = get_audio_sinks();
             }
 
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -22,6 +22,12 @@ fn default_true() -> bool {
 pub struct PartyConfig {
     #[serde(default = "default_true")]
     pub enable_kwin_script: bool,
+    /// KWin placement mode. `true` (default): assign each instance to its chosen
+    /// monitor (multi-monitor). `false`: classic single-screen splitscreen —
+    /// ignore assignments and tile windows on whatever screen KWin opens them
+    /// on (the original upstream behavior).
+    #[serde(default = "default_true")]
+    pub kwin_multimonitor: bool,
     #[serde(default = "default_true")]
     pub gamescope_fix_lowres: bool,
     #[serde(default = "default_true")]
@@ -54,6 +60,7 @@ impl Default for PartyConfig {
     fn default() -> Self {
         PartyConfig {
             enable_kwin_script: true,
+            kwin_multimonitor: true,
             gamescope_fix_lowres: true,
             gamescope_sdl_backend: true,
             gamescope_force_grab_cursor: false,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -8,8 +8,15 @@ pub struct Instance {
     pub profname: String,
     pub profselection: usize,
     pub monitor: usize,
+    /// Audio sink name for this instance's `PULSE_SINK` ("" = system default).
+    pub audio_sink: String,
     pub width: u32,
     pub height: u32,
+    /// Manual per-instance render-resolution override. `None` = render at the
+    /// monitor/tile size (default). `Some((w, h))` makes the game render at w×h
+    /// (gamescope `-w/-h`) while still being upscaled to fill the assigned
+    /// monitor (gamescope `-W/-H`) — e.g. force 1600×900 on a 1920×1200 screen.
+    pub res_override: Option<(u32, u32)>,
 }
 
 pub fn set_instance_resolutions(
@@ -37,6 +44,9 @@ pub fn set_instance_resolutions(
             h = 600;
             w = (h as f32 * ratio) as u32;
         }
+        // res_override drives the gamescope *nested* render size (-w/-h) in
+        // launch.rs; the output (-W/-H) stays at the monitor size so the window
+        // still fills the screen.
         instance.width = w;
         instance.height = h;
     }
@@ -76,6 +86,9 @@ pub fn set_instance_resolutions_multimonitor(
             h = 600;
             w = (h as f32 * ratio) as u32;
         }
+        // res_override drives the gamescope *nested* render size (-w/-h) in
+        // launch.rs; the output (-W/-H) stays at the monitor size so the window
+        // still fills the screen.
         instance.width = w;
         instance.height = h;
     }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -45,7 +45,23 @@ pub fn launch_game(
             false => "splitscreen_kwin.js",
         };
 
-        kwin_dbus_start_script(PATH_RES.join(script)).map_err(|e| format!("Failed to start KWin script: {}", e))?;
+        // Bake the per-instance monitor assignment into the script so KWin can
+        // place each gamescope window on its assigned screen (the SDL backend's
+        // --display-index doesn't apply on the Wayland backend). PARTYDECK_USE_
+        // ASSIGNMENTS selects multi-monitor placement vs classic splitscreen.
+        let assignments: Vec<String> = instances.iter().map(|i| i.monitor.to_string()).collect();
+        let template = std::fs::read_to_string(PATH_RES.join(script))
+            .map_err(|e| format!("Failed to read KWin script: {}", e))?;
+        let generated = template
+            .replace("PARTYDECK_ASSIGNMENTS", &format!("[{}]", assignments.join(", ")))
+            .replace("PARTYDECK_USE_ASSIGNMENTS", &cfg.kwin_multimonitor.to_string());
+        std::fs::create_dir_all(PATH_PARTY.join("tmp"))
+            .map_err(|e| format!("Failed to create tmp dir: {}", e))?;
+        let active_script = PATH_PARTY.join("tmp").join("splitscreen_active.js");
+        std::fs::write(&active_script, generated)
+            .map_err(|e| format!("Failed to write KWin script: {}", e))?;
+
+        kwin_dbus_start_script(active_script).map_err(|e| format!("Failed to start KWin script: {}", e))?;
     }
 
     let sleep_time = match h.pause_between_starts {
@@ -109,6 +125,14 @@ pub fn launch_cmds(
             && !PATH_STEAM.join("steam/steamapps/common/SteamLinuxRuntime_4").exists())
     {
         return Err(format!("Steam Runtime {runtime} not found! Runtime must be installed on the same drive that the Steam client is installed on.").into());
+    }
+
+    // Empty directory used to mask out a handler's `game_null_paths` entries
+    // that are directories (bind-mounted over them via bwrap). bwrap requires
+    // the bind source to exist, and clear_tmp() wipes tmp/ after every run, so
+    // (re)create it here or directory masking silently fails to launch.
+    if !h.game_null_paths.is_empty() {
+        let _ = std::fs::create_dir_all(PATH_PARTY.join("tmp/null"));
     }
 
     let mut cmds: Vec<Command> = (0..instances.len())
@@ -186,6 +210,10 @@ pub fn launch_cmds(
                 }
             }
         }
+        // Route this instance's audio to its chosen sink (PipeWire/PulseAudio).
+        if !instance.audio_sink.is_empty() {
+            cmd.env("PULSE_SINK", &instance.audio_sink);
+        }
 
         // Gamescope args
         if h.use_mangohud {
@@ -197,12 +225,24 @@ pub fn launch_cmds(
             "-H",
             &instance.height.to_string(),
         ]);
+        // Optional render-resolution override: gamescope renders the game at
+        // this size and upscales it to the output (-W/-H = the full monitor).
+        if let Some((rw, rh)) = instance.res_override {
+            cmd.args(["-w", &rw.to_string(), "-h", &rh.to_string()]);
+        }
         if cfg.gamescope_force_grab_cursor {
             cmd.arg("--force-grab-cursor");
         }
         if cfg.gamescope_sdl_backend {
             cmd.arg("--backend=sdl");
             cmd.arg(format!("--display-index={}", instance.monitor));
+        } else if cfg.enable_kwin_script {
+            // With the KWin script doing per-monitor placement, use the Wayland
+            // backend (the SDL backend falls back to a headless/dying window on
+            // some NVIDIA/KDE setups). Without the KWin script there's nothing to
+            // place the windows, so let gamescope pick its own backend rather
+            // than forcing Wayland on every setup.
+            cmd.arg("--backend=wayland");
         }
         if cfg.kbm_support {
             let mut instance_has_keyboard = false;
@@ -374,17 +414,33 @@ pub fn launch_cmds(
 
         cmd.arg(&path_exec);
 
+        let (render_w, render_h) = instance
+            .res_override
+            .unwrap_or((instance.width, instance.height));
         for arg in h.args.split_whitespace() {
-            let processed_arg = match arg {
-                "$PROFILE" => &instance.profname,
-                "$WIDTH" => &instance.width.to_string(),
-                "$HEIGHT" => &instance.height.to_string(),
-                "$RESOLUTION" => &format!("{}x{}", instance.width, instance.height),
-                "$INSTANCECOUNT" => &instances.len().to_string(),
-                "$INSTANCENUM" => &i.to_string(),
-                "$GAMEDIR" => &gamedir.os_fmt(win),
-                "$HANDLERDIR" => &h.path_handler.os_fmt(win),
-                _ => &String::from(arg).sanitize_path(),
+            // Substring substitution so tokens can be embedded inside an arg,
+            // e.g. "-ResX=$WIDTH" -> "-ResX=1600" (Unreal Engine games).
+            let processed_arg = if arg.contains('$') {
+                let substituted = arg
+                    .replace("$PROFILE", &instance.profname)
+                    .replace("$WIDTH", &render_w.to_string())
+                    .replace("$HEIGHT", &render_h.to_string())
+                    .replace("$RESOLUTION", &format!("{}x{}", render_w, render_h))
+                    .replace("$INSTANCECOUNT", &instances.len().to_string())
+                    .replace("$INSTANCENUM", &i.to_string())
+                    .replace("$GAMEDIR", &gamedir.os_fmt(win))
+                    .replace("$HANDLERDIR", &h.path_handler.os_fmt(win));
+                // The path tokens expand to real, already-formatted paths that
+                // must pass through verbatim; every other arg is sanitized like
+                // the no-token branch (so e.g. -ResX=$WIDTH keeps the same
+                // cleaning it had before substitution was added).
+                if arg.contains("$GAMEDIR") || arg.contains("$HANDLERDIR") {
+                    substituted
+                } else {
+                    substituted.sanitize_path()
+                }
+            } else {
+                String::from(arg).sanitize_path()
             };
             cmd.arg(processed_arg);
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -261,6 +261,62 @@ pub fn kwin_dbus_unload_script() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+// ---------- Audio sink helpers (PipeWire/PulseAudio via pactl) ----------
+
+/// Names of the available audio sinks, via `pactl list short sinks`. Each name
+/// is suitable for use as a per-instance `PULSE_SINK` value.
+pub fn get_audio_sinks() -> Vec<String> {
+    let mut sinks = Vec::new();
+    let Ok(out) = Command::new("pactl").args(["list", "short", "sinks"]).output() else {
+        return sinks;
+    };
+    for line in String::from_utf8_lossy(&out.stdout).lines() {
+        // columns: id \t name \t driver \t format \t state
+        if let Some(name) = line.split('\t').nth(1) {
+            if !name.is_empty() {
+                sinks.push(name.to_string());
+            }
+        }
+    }
+    sinks
+}
+
+/// Creates a virtual (null) sink usable as a routing target that can be wired
+/// to real hardware in a patchbay like qpwgraph. No-op if it already exists.
+pub fn create_virtual_sink(name: &str) -> Result<(), Box<dyn Error>> {
+    if get_audio_sinks().iter().any(|s| s == name) {
+        return Ok(());
+    }
+    let status = Command::new("pactl")
+        .args([
+            "load-module",
+            "module-null-sink",
+            &format!("sink_name={name}"),
+            &format!("sink_properties=device.description={name}"),
+        ])
+        .status()?;
+    if !status.success() {
+        return Err("pactl failed to create the virtual sink".into());
+    }
+    Ok(())
+}
+
+/// Unloads every null-sink module whose sink name starts with `prefix`.
+pub fn remove_virtual_sinks(prefix: &str) -> Result<(), Box<dyn Error>> {
+    let out = Command::new("pactl").args(["list", "short", "modules"]).output()?;
+    let needle = format!("sink_name={prefix}");
+    for line in String::from_utf8_lossy(&out.stdout).lines() {
+        let mut cols = line.split('\t');
+        let id = cols.next().unwrap_or("");
+        let module = cols.next().unwrap_or("");
+        let args = cols.next().unwrap_or("");
+        if module == "module-null-sink" && args.contains(&needle) {
+            let _ = Command::new("pactl").args(["unload-module", id]).status();
+        }
+    }
+    Ok(())
+}
+
 pub trait SanitizePath {
     fn sanitize_path(&self) -> String;
 }


### PR DESCRIPTION
## What

Three related per-instance "placement" features for splitscreen sessions:

### Per-instance render resolution + arg-token substitution
- Each instance gets an optional render-resolution override: gamescope renders the game at `-w/-h` and upscales it to the monitor output (`-W/-H`). Useful for weak-GPU downscaling and odd panels (e.g. 16:10). Exposed as a monitor-icon toggle on the Instances page.
- Argument tokens (`$WIDTH`, `$HEIGHT`, `$RESOLUTION`, `$PROFILE`, `$GAMEDIR`, …) are now substituted as **substrings**, so a token can be embedded inside an argument, e.g. `-ResX=$WIDTH` → `-ResX=1600` (needed by some Unreal Engine games). Path tokens (`$GAMEDIR`/`$HANDLERDIR`) pass through verbatim; every other arg is still run through `sanitize_path()`.

### KWin multi-monitor placement (+ classic fallback)
- The KWin splitscreen scripts now assign each instance to its chosen monitor by baking a per-instance assignment array into the script at launch, so multi-monitor placement works on the **Wayland** backend (where `--display-index` doesn't apply), not only the SDL backend.
- A new `kwin_multimonitor` setting toggles between this and **classic single-screen splitscreen** (ignore assignments, split whatever screen KWin opens windows on — the original behavior).
- The Wayland backend is only forced when the KWin script is enabled (it's what does the placement); otherwise gamescope picks its own backend.

### Per-instance audio sinks
- Each instance can route its audio to a chosen PipeWire/PulseAudio sink (`PULSE_SINK`), with buttons to create/remove/refresh `PartyDeck-N` virtual sinks (for routing players to different outputs via a patchbay). `pactl` errors are surfaced; sink naming uses the lowest free index.

Also: new instances auto-assign across available monitors, and `tmp/null` is recreated each launch so `game_null_paths` directory masking works.

## Testing
`cargo check` + `cargo test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
