### PR TITLE
Per-profile Goldberg SteamID pinning + save status/import

### DIFF
--- a/src/app/app_pages.rs
+++ b/src/app/app_pages.rs
@@ -96,34 +96,123 @@ impl PartyApp {
 
     pub fn display_page_profiles(&mut self, ui: &mut Ui) {
         ui.heading("Profiles");
+
+        // Each profile owns a pinned Goldberg SteamID, which fixes its game-save
+        // identity (e.g. the EldenRing/<SteamID>/ER0000.co2 folder). If the
+        // currently-selected game declares where its saves live (`save_dir`), we
+        // also show per-profile save status + an import button for that game.
+        let save_ctx: Option<(String, String)> = self
+            .handlers
+            .get(self.selected_handler)
+            .filter(|h| !h.save_dir.is_empty())
+            .map(|h| (h.name.clone(), h.save_dir.clone()));
+
+        if let Some((game, _)) = &save_ctx {
+            ui.label(format!(
+                "Showing saves for: {game}  (select a different game on the left to switch)"
+            ));
+        } else {
+            ui.label("Each profile is a fixed identity (SteamID) with its own saves.");
+        }
         ui.separator();
+
+        let profiles = self.profiles.clone();
+        let mut dirty = false;
+
         egui::ScrollArea::vertical()
-            .max_height(ui.available_height() - 16.0)
+            .max_height(ui.available_height() - 40.0)
             .auto_shrink(false)
             .show(ui, |ui| {
-                for profile in &self.profiles {
-                    if ui.selectable_value(&mut 0, 1, profile).clicked() {
-                        if let Err(_) = std::process::Command::new("xdg-open")
-                            .arg(PATH_PARTY.join("profiles").join(profile))
-                            .status()
+                for profile in &profiles {
+                    let steamid = ensure_profile_steamid(profile);
+                    ui.horizontal(|ui| {
+                        ui.strong(profile);
+                        ui.label(RichText::new(format!("SteamID {steamid}")).monospace());
+
+                        if ui
+                            .button("✎")
+                            .on_hover_text("Set a specific SteamID (e.g. to match an existing save you're importing)")
+                            .clicked()
+                            && let Ok(Some(input)) = dialog::Input::new(
+                                "Enter SteamID64 (17-digit, e.g. 76561198007525187):",
+                            )
+                            .title(&format!("SteamID for {profile}"))
+                            .show()
+                        {
+                            match input.trim().parse::<u64>() {
+                                Ok(id) if id > STEAMID64_BASE => {
+                                    if let Err(e) = write_profile_steamid(profile, id) {
+                                        msg("Error", &format!("Couldn't write SteamID: {e}"));
+                                    }
+                                }
+                                _ => msg(
+                                    "Invalid SteamID",
+                                    "Must be a 17-digit SteamID64 for an individual account.",
+                                ),
+                            }
+                        }
+
+                        if ui.button("📁").on_hover_text("Open profile folder").clicked()
+                            && std::process::Command::new("xdg-open")
+                                .arg(PATH_PARTY.join("profiles").join(profile))
+                                .status()
+                                .is_err()
                         {
                             msg("Error", "Couldn't open profile directory!");
                         }
-                    };
+
+                        if let Some((_, save_dir)) = &save_ctx {
+                            if profile_has_save(profile, save_dir, steamid) {
+                                ui.colored_label(
+                                    egui::Color32::from_rgb(90, 200, 120),
+                                    "● has save",
+                                );
+                            } else {
+                                ui.colored_label(egui::Color32::GRAY, "○ no save");
+                            }
+                            if ui
+                                .button("⬇ Import save")
+                                .on_hover_text(
+                                    "Copy an existing .co2/.sl2 into this profile's save folder.\nTip: for an existing character, first set this profile's SteamID to the save's original ID.",
+                                )
+                                .clicked()
+                                && let Some(file) = FileDialog::new()
+                                    .set_title(&format!("Pick a save to import for {profile}"))
+                                    .set_directory(&*PATH_HOME)
+                                    .add_filter("Souls save files", &["co2", "sl2"])
+                                    .add_filter("All files", &["*"])
+                                    .pick_file()
+                            {
+                                match import_save_into_profile(profile, save_dir, steamid, &file) {
+                                    Ok(dest) => {
+                                        msg("Imported", &format!("Copied to:\n{}", dest.display()))
+                                    }
+                                    Err(e) => msg("Import failed", &format!("{e}")),
+                                }
+                            }
+                        }
+                    });
                 }
             });
-        if ui.button("New").clicked() {
-            if let Some(name) = dialog::Input::new("Enter name (must be alphanumeric):")
+
+        ui.separator();
+        if ui.button("New Profile").clicked() {
+            if let Ok(Some(name)) = dialog::Input::new("Enter name (must be alphanumeric):")
                 .title("New Profile")
                 .show()
-                .expect("Could not display dialog box")
             {
                 if !name.is_empty() && name.chars().all(char::is_alphanumeric) {
-                    create_profile(&name).unwrap();
+                    if let Err(e) = create_profile(&name) {
+                        msg("Error", &format!("Couldn't create profile: {e}"));
+                    }
                 } else {
                     msg("Error", "Invalid name");
                 }
             }
+            dirty = true;
+        }
+
+        if dirty {
             self.profiles = scan_profiles(false);
         }
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -52,6 +52,13 @@ pub struct Handler {
     pub steam_appid: Option<u32>,
 
     pub game_null_paths: Vec<String>,
+
+    /// Where this game stores its per-account save, relative to a profile's
+    /// Windows user dir, using `$STEAMID` for the Goldberg account id — e.g.
+    /// `AppData/Roaming/EldenRing/$STEAMID`. Lets PartyDeck show which profile
+    /// owns which save and import existing saves. Empty = unknown (feature off).
+    #[serde(default)]
+    pub save_dir: String,
 }
 
 impl Default for Handler {
@@ -81,6 +88,7 @@ impl Default for Handler {
             steam_appid: None,
 
             game_null_paths: Vec::new(),
+            save_dir: String::new(),
         }
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -6,7 +6,7 @@ use crate::handler::*;
 use crate::input::*;
 use crate::instance::*;
 use crate::paths::*;
-use crate::profiles::{create_profile, create_profile_gamesave};
+use crate::profiles::{create_profile, create_profile_gamesave, ensure_profile_steamid};
 use crate::util::*;
 
 pub fn setup_profiles(
@@ -18,12 +18,15 @@ pub fn setup_profiles(
         if instance.profname.starts_with(".") {
             create_profile(&instance.profname)?;
         }
+        // Guarantee every profile (including pre-existing named ones) has a
+        // pinned Goldberg SteamID, so its game saves are stable and reusable.
+        let steamid = ensure_profile_steamid(&instance.profname);
         if h.is_saved_handler() {
             create_profile_gamesave(&instance.profname, h)?;
         }
         println!(
-            "[partydeck] - Profile: {}, Monitor: {}, Resolution: {}x{}",
-            instance.profname, instance.monitor, instance.width, instance.height
+            "[partydeck] - Profile: {}, SteamID: {}, Monitor: {}, Resolution: {}x{}",
+            instance.profname, steamid, instance.monitor, instance.width, instance.height
         );
     }
 

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,11 +1,145 @@
 use std::error::Error;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::{handler::Handler, paths::*, util::copy_dir_recursive};
+
+/// SteamID64 base for individual accounts (account id = 0): 0x0110000100000000.
+pub const STEAMID64_BASE: u64 = 76561197960265728;
+
+/// A deterministic, valid SteamID64 derived from a profile name. Stable per
+/// name, so a profile keeps the same Goldberg identity — and therefore the same
+/// game save folder (e.g. `EldenRing/<SteamID>/ER0000.co2`) — across launches.
+pub fn generate_steamid(name: &str) -> u64 {
+    // FNV-1a (64-bit), a *fixed* hash. std's DefaultHasher is explicitly not
+    // guaranteed stable across Rust/std versions, and this id becomes the
+    // on-disk save-folder name — so a profile must derive the same SteamID
+    // forever, even across a toolchain upgrade.
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in name.bytes() {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    // account id is the low 32 bits; keep it non-zero so the id is well-formed.
+    let account_id = (hash as u32).max(1) as u64;
+    STEAMID64_BASE + account_id
+}
+
+/// Path to a profile's Goldberg user config (the per-profile `GseSavePath`
+/// settings file that Goldberg reads `account_name`/`account_steamid` from).
+pub fn profile_user_config_path(name: &str) -> PathBuf {
+    PATH_PARTY.join(format!("profiles/{name}/steam/settings/configs.user.ini"))
+}
+
+/// Parse `account_steamid` out of a Goldberg `configs.user.ini` body. Tolerant
+/// of the comments/blank lines Goldberg writes around it.
+fn parse_account_steamid(contents: &str) -> Option<u64> {
+    for line in contents.lines() {
+        if let Some(val) = line.trim().strip_prefix("account_steamid=")
+            && let Ok(id) = val.trim().parse::<u64>()
+        {
+            return Some(id);
+        }
+    }
+    None
+}
+
+/// Read a profile's pinned Goldberg SteamID, if one has been written.
+pub fn read_profile_steamid(name: &str) -> Option<u64> {
+    parse_account_steamid(&std::fs::read_to_string(profile_user_config_path(name)).ok()?)
+}
+
+fn write_ini(path: &Path, contents: &str) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, contents)
+}
+
+/// Write a profile's Goldberg user config, pinning `account_steamid` so the
+/// identity (and the game's save folder) is stable and reusable. Goldberg may
+/// read this from either the per-profile `GseSavePath` settings or the default
+/// `%APPDATA%/GSE Saves` location (which PartyDeck isolates per profile via
+/// `windata`), so we write both — both are per-profile and harmless, and one
+/// is whichever Goldberg actually reads. Preserves the account name.
+pub fn write_profile_steamid(name: &str, steamid: u64) -> Result<(), std::io::Error> {
+    let contents =
+        format!("[user::general]\naccount_name={name}\naccount_steamid={steamid}\nlanguage=english\n");
+    // Primary: GseSavePath/settings (must succeed).
+    write_ini(&profile_user_config_path(name), &contents)?;
+    // Reinforcement: the default %APPDATA%/GSE Saves location (best-effort).
+    let _ = write_ini(
+        &PATH_PARTY.join(format!(
+            "profiles/{name}/windata/AppData/Roaming/GSE Saves/settings/configs.user.ini"
+        )),
+        &contents,
+    );
+    Ok(())
+}
+
+/// Ensure a profile has a pinned SteamID, generating + persisting one if it has
+/// none yet (e.g. profiles created before this feature existed). Returns the id.
+pub fn ensure_profile_steamid(name: &str) -> u64 {
+    if let Some(id) = read_profile_steamid(name) {
+        return id;
+    }
+    let id = generate_steamid(name);
+    let _ = write_profile_steamid(name, id);
+    id
+}
+
+/// Resolve a handler's `save_dir` template (with `$STEAMID`) to a profile's
+/// actual on-disk save directory (under its per-profile `windata`, which
+/// PartyDeck binds as the game's Windows user dir at launch).
+pub fn profile_save_dir(profname: &str, save_dir_template: &str, steamid: u64) -> PathBuf {
+    let rel = save_dir_template
+        .replace('\\', "/")
+        .replace("$STEAMID", &steamid.to_string());
+    PATH_PARTY
+        .join("profiles")
+        .join(profname)
+        .join("windata")
+        .join(rel)
+}
+
+/// Whether a profile already holds a (non-empty) save for the given handler
+/// save-dir template + SteamID.
+pub fn profile_has_save(profname: &str, save_dir_template: &str, steamid: u64) -> bool {
+    if save_dir_template.is_empty() {
+        return false;
+    }
+    let dir = profile_save_dir(profname, save_dir_template, steamid);
+    std::fs::read_dir(&dir)
+        .map(|mut entries| entries.any(|e| e.is_ok()))
+        .unwrap_or(false)
+}
+
+/// Copy an existing save file into a profile's save directory for the given
+/// handler save-dir template + SteamID (creating the directory). Copy, not
+/// symlink, so the original isn't mutated as the game writes saves. Returns the
+/// destination path.
+pub fn import_save_into_profile(
+    profname: &str,
+    save_dir_template: &str,
+    steamid: u64,
+    src: &Path,
+) -> Result<PathBuf, Box<dyn Error>> {
+    if save_dir_template.is_empty() {
+        return Err("This game's handler has no save_dir set, so PartyDeck doesn't know where its saves live.".into());
+    }
+    let dir = profile_save_dir(profname, save_dir_template, steamid);
+    std::fs::create_dir_all(&dir)?;
+    let filename = src.file_name().ok_or("source path has no filename")?;
+    let dest = dir.join(filename);
+    std::fs::copy(src, &dest)?;
+    Ok(dest)
+}
 
 // Makes a folder and sets up Goldberg Steam Emu profile for Steam games
 pub fn create_profile(name: &str) -> Result<(), std::io::Error> {
     if PATH_PARTY.join(format!("profiles/{name}")).exists() {
+        // Existing profile: make sure it has a pinned SteamID even if it predates
+        // this feature, so its saves stay stable and reusable.
+        ensure_profile_steamid(name);
         return Ok(());
     }
 
@@ -23,8 +157,8 @@ pub fn create_profile(name: &str) -> Result<(), std::io::Error> {
     std::fs::create_dir_all(path_profile.join("home/.config"))?;
     std::fs::create_dir_all(path_steam.clone())?;
 
-    let usersettings = format!("[user::general]\naccount_name={name}");
-    std::fs::write(path_steam.join("configs.user.ini"), usersettings)?;
+    // Pin a stable per-profile Goldberg SteamID (identity + save folder name).
+    write_profile_steamid(name, generate_steamid(name))?;
 
     println!("[partydeck] Profile created successfully");
     Ok(())
@@ -122,3 +256,45 @@ pub static GUEST_NAMES: [&str; 33] = [
     "Lich", "Smores", "Canary", "Trico", "Yorda", "Wander", "Agro", "Jak", "Daxter", "Soap",
     "Ghost", "Tomi", "Masaki",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_steamid_is_valid_and_distinct() {
+        let a = generate_steamid("Tarnished_A");
+        let b = generate_steamid("Tarnished_B");
+        // Above the individual-account base, and deterministic per name.
+        assert!(a > STEAMID64_BASE);
+        assert!(b > STEAMID64_BASE);
+        assert_eq!(a, generate_steamid("Tarnished_A"));
+        assert_ne!(a, b);
+        // 17-digit SteamID64, like a real one.
+        assert_eq!(a.to_string().len(), 17);
+    }
+
+    #[test]
+    fn parse_steamid_from_goldberg_ini() {
+        // The exact shape Goldberg persists (comments + blanks around the value).
+        let ini = "[user::general]\n\n# user account name\naccount_name=gse orca\n\n# Steam64 format\naccount_steamid=76561198328811168\n\nlanguage=english\n";
+        assert_eq!(parse_account_steamid(ini), Some(76561198328811168));
+        // Absent -> None.
+        assert_eq!(parse_account_steamid("[user::general]\naccount_name=x\n"), None);
+    }
+
+    #[test]
+    fn save_dir_substitutes_steamid_and_lands_under_windata() {
+        let p = profile_save_dir("Anish", "AppData/Roaming/EldenRing/$STEAMID", 76561198007525187);
+        let s = p.to_string_lossy();
+        assert!(s.contains("/profiles/Anish/windata/AppData/Roaming/EldenRing/76561198007525187"));
+        // Backslash templates are normalised too.
+        let p2 = profile_save_dir("Anish", "AppData\\Local\\BET\\$STEAMID", 123);
+        assert!(p2.to_string_lossy().contains("windata/AppData/Local/BET/123"));
+    }
+
+    #[test]
+    fn has_save_false_when_no_template() {
+        assert!(!profile_has_save("Anish", "", 1));
+    }
+}


### PR DESCRIPTION
## What

Make per-profile save identities stable and manageable for Goldberg (Steam-emu) games.

### Per-profile pinned SteamID
- Each profile pins a stable, valid SteamID64 derived from its name (FNV-1a — a fixed hash, not `DefaultHasher`, since this id becomes the on-disk save-folder name and must stay constant across toolchain upgrades). The id is written to the profile's Goldberg `configs.user.ini`, so its identity — and therefore its game-save folder — is reusable across launches.
- The Profiles page shows each profile's SteamID and lets you set a specific one (e.g. to match an existing save you're importing). Pre-existing profiles get a pinned id on next launch.

### Save status + import
- New optional `Handler.save_dir` template (with `$STEAMID`), e.g. `AppData/Roaming/EldenRing/$STEAMID`. When set, the Profiles page shows a per-profile has-save / no-save indicator for the selected game and an "Import save" button that copies an existing save file into the profile's save folder.

## Testing
`cargo test` — 4 unit tests covering SteamID validity/determinism, Goldberg ini parsing, and `save_dir` resolution.

## Note
Touches `display_page_profiles`, which is also extended by the EOS PR (`feat/eos-emu-support`); if both land, that function needs a trivial merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
